### PR TITLE
moved shared scripts above server scripts (fix for issue #3)

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,10 +2,11 @@ fx_version 'bodacious'
 game 'gta5'
 lua54 'yes'
 
+shared_script 'config.lua'
+
 server_scripts {
 	'@oxmysql/lib/MySQL.lua',
 	'server/main.lua'
 }
 
 client_script 'client/main.lua'
-shared_script 'config.lua'


### PR DESCRIPTION
so I believe the issue causing the error on line 34 of the server is because the config file is not loaded yet and therefore the object 'Config' is empty/non-existent moving the loading above should in theory fix it, unfortunately I do not have access to the game at the moment to test this theory out.